### PR TITLE
feat: Create py-omop2neo4j-lpg Python package

### DIFF
--- a/py-omop2neo4j-lpg/.env.example
+++ b/py-omop2neo4j-lpg/.env.example
@@ -1,0 +1,25 @@
+# --- PostgreSQL Connection Settings ---
+# These should be prefixed with 'PG_' for pydantic-settings to pick them up
+PG_HOST=localhost
+PG_PORT=5432
+PG_USER=postgres
+PG_PASSWORD=your_postgres_password
+PG_DATABASE=ohdsi
+PG_SCHEMA=cdm_v5
+
+# --- Neo4j Connection Settings ---
+# These should be prefixed with 'NEO4J_'
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=StrongPass123
+NEO4J_DATABASE=neo4j
+
+# --- File Path Settings ---
+# Local directory where PostgreSQL will export CSVs
+EXPORT_DIR=export
+# Directory for neo4j-admin import files (relative to the Neo4j container's import volume)
+BULK_IMPORT_DIR=import_transformed
+
+# --- Tuning Parameters ---
+LOAD_CSV_BATCH_SIZE=20000
+TRANSFORMATION_CHUNK_SIZE=200000

--- a/py-omop2neo4j-lpg/README.md
+++ b/py-omop2neo4j-lpg/README.md
@@ -1,0 +1,151 @@
+# py-omop2neo4j-lpg
+
+A robust, high-performance Python package to orchestrate the migration of OMOP vocabulary tables from PostgreSQL to a mature Labeled Property Graph (LPG) in Neo4j.
+
+This tool is designed for efficiency and scalability, using native database bulk loading tools wherever possible to handle large vocabulary datasets.
+
+## Key Features
+
+- **Two Loading Methods**:
+  - **Online `LOAD CSV`**: For smaller datasets or when the Neo4j instance must remain online.
+  - **Offline `neo4j-admin import`**: A high-performance method for very large datasets that can afford downtime.
+- **Mature Graph Model**: Creates a rich, query-optimized graph with dynamic labels for domains (e.g., `:Drug`), dynamic relationship types (e.g., `:MAPS_TO`), and special labels for query optimization (e.g., `:Standard`).
+- **Performance Focused**: Uses PostgreSQL `COPY` and Neo4j's native import tools to avoid slow, client-side data streaming.
+- **Memory Efficient**: Implements chunking for the offline transformation step to handle datasets that exceed available RAM.
+- **Simple CLI**: A user-friendly command-line interface to orchestrate the entire ETL process.
+
+## Prerequisites
+
+1.  **Python**: Python 3.9+
+2.  **PostgreSQL**: A running PostgreSQL instance with the OMOP CDM vocabulary tables.
+3.  **Neo4j**: A running Neo4j 5.x instance.
+4.  **APOC Plugin**: The [APOC plugin](https://neo4j.com/labs/apoc/) must be installed in Neo4j. This is required for both loading methods.
+5.  **Docker (Recommended)**: A `docker-compose.yml` is provided for easy setup of a pre-configured Neo4j instance.
+
+## Installation
+
+1.  Clone the repository:
+    ```bash
+    git clone <repository_url>
+    cd py-omop2neo4j-lpg
+    ```
+2.  Create a virtual environment and install the package in editable mode:
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -e .
+    ```
+
+## Configuration
+
+The tool is configured using environment variables. You can create a `.env` file in the project root directory to manage them.
+
+1.  Copy the example file:
+    ```bash
+    cp .env.example .env
+    ```
+2.  Edit the `.env` file with your database credentials and preferred settings. The tool will automatically load these settings.
+
+## Usage
+
+The tool provides two main workflows for migrating the data.
+
+### Method 1: Online Loading via `LOAD CSV`
+
+This method is suitable for smaller vocabularies or situations where the Neo4j database must remain online.
+
+**Step 1: Extract Data from PostgreSQL**
+
+This command connects to PostgreSQL and exports the necessary vocabulary tables into CSV files in the directory specified by `EXPORT_DIR` (default: `export/`).
+
+```bash
+py-omop2neo4j-lpg extract
+```
+
+**Step 2: Place CSVs in Neo4j Import Directory**
+
+The `LOAD CSV` command requires the CSV files to be inside the Neo4j server's configured `import` directory. If you are using the provided `docker-compose.yml`, the local `./export` directory is automatically mapped to the container's `/import` directory, so this step is already handled.
+
+**Step 3: Run the Online Loader**
+
+This command will connect to Neo4j and run a series of `LOAD CSV` Cypher queries to import the data. It will wipe the database first (after confirmation) and run validation checks upon completion.
+
+```bash
+py-omop2neo4j-lpg load-csv
+```
+
+### Method 2: Offline Loading via `neo4j-admin import`
+
+This is the fastest method and is recommended for very large vocabularies. It requires the Neo4j service to be stopped during the import.
+
+**Step 1: Extract Data from PostgreSQL**
+
+This is the same as in Method 1.
+```bash
+py-omop2neo4j-lpg extract
+```
+
+**Step 2: Prepare Files for Bulk Import**
+
+This command reads the extracted CSVs and transforms them into a set of new files specially formatted for the `neo4j-admin` tool. These new files will be saved in a separate directory (default: `import_transformed/`).
+
+```bash
+py-omop2neo4j-lpg prepare-bulk
+```
+This will output a `neo4j-admin database import full ...` command to your console.
+
+**Step 3: Run the Bulk Import**
+
+1.  **Stop Neo4j**:
+    ```bash
+    docker-compose stop neo4j
+    ```
+2.  **Run the command**: Copy the `neo4j-admin` command printed in the previous step and run it. **Note:** You must execute this command *inside* the stopped container.
+    ```bash
+    # Example for running the command with Docker
+    docker-compose exec neo4j <paste_the_entire_neo4j-admin_command_here>
+    ```
+3.  **Set Permissions**: The import tool may create files owned by `root`. Fix ownership so the `neo4j` user can start the database.
+    ```bash
+    docker-compose exec -u root neo4j chown -R neo4j:neo4j /data
+    ```
+4.  **Restart Neo4j**:
+    ```bash
+    docker-compose start neo4j
+    ```
+
+**Step 4: Create Indexes**
+
+After the bulk import is complete and Neo4j is running again, you **must** create the schema constraints and indexes.
+
+```bash
+py-omop2neo4j-lpg create-indexes
+```
+
+### Validation
+
+You can run the validation checks at any time to verify the integrity of the graph:
+
+```bash
+py-omop2neo4j-lpg validate
+```
+
+## Performance Tuning Guide
+
+For large vocabularies, you must configure Neo4j's memory settings appropriately. These can be set in your `neo4j.conf` file or as environment variables in the `docker-compose.yml` file.
+
+-   `NEO4J_server_memory_heap_initial_size` & `NEO4J_server_memory_heap_max_size`: Controls the Java heap space. The import process can be memory-intensive. A good starting point is `4G` to `8G`. Set both to the same value for best performance.
+-   `NEO4J_server_memory_pagecache_size`: This is critical for query performance *after* the import. It should be large enough to hold the graph data. For the import process itself, it's less critical but still important. A setting of `8G` or more is recommended for large graphs.
+
+Monitor your system's memory usage and adjust these settings based on your available hardware.
+
+## CLI Command Reference
+
+-   `extract`: Extracts data from PostgreSQL to CSVs.
+-   `clear-db`: Wipes the Neo4j database.
+-   `load-csv`: Imports data using the online `LOAD CSV` method.
+-   `prepare-bulk`: Prepares CSVs for the offline bulk importer.
+-   `create-indexes`: Creates schema constraints and indexes.
+-   `validate`: Runs post-load validation checks.
+
+Use `py-omop2neo4j-lpg <command> --help` for more details on each command.

--- a/py-omop2neo4j-lpg/docker-compose.yml
+++ b/py-omop2neo4j-lpg/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  neo4j:
+    image: neo4j:5.18.0 # Using a specific version is good practice
+    container_name: neo4j-omop-vocab
+    environment:
+      # Default credentials. Change these for production.
+      - NEO4J_AUTH=neo4j/StrongPass123
+      # Enable APOC and file imports
+      - NEO4J_apoc_export_file_enabled=true
+      - NEO4J_apoc_import_file_enabled=true
+      - NEO4J_apoc_import_file_use__neo4j__config=true
+      - NEO4JLABS_PLUGINS=["apoc"]
+      # Allow read/write from the /import directory. This is crucial for LOAD CSV.
+      - NEO4J_server_filesystem_import_directory=/import
+      - NEO4J_server_filesystem_security_enabled=false # Use with caution
+
+      # --- PERFORMANCE TUNING (ADJUST BASED ON YOUR HARDWARE) ---
+      # Advise users to set heap to be large enough for transaction state,
+      # and pagecache to be large enough to hold the graph.
+      - NEO4J_server_memory_heap_initial_size=4G
+      - NEO4J_server_memory_heap_max_size=4G
+      - NEO4J_server_memory_pagecache_size=8G
+    ports:
+      - "7474:7474" # HTTP
+      - "7687:7687" # Bolt
+    volumes:
+      # Persists Neo4j data between runs
+      - ./neo4j/data:/data
+      # Maps a local directory to Neo4j's import directory.
+      # Place the CSV files from the 'extract' command here.
+      - ./export:/import

--- a/py-omop2neo4j-lpg/pyproject.toml
+++ b/py-omop2neo4j-lpg/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "py-omop2neo4j-lpg"
+version = "0.1.0"
+description = "A robust, high-performance Python package to orchestrate the migration of OMOP vocabulary tables from PostgreSQL to a mature Labeled Property Graph (LPG) in Neo4j."
+authors = ["Gowtham Rao <rao@ohdsi.org>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+psycopg2-binary = "*"
+neo4j = "*"
+pandas = "*"
+numpy = "*"
+click = "*"
+pydantic-settings = "*"
+python-dotenv = "*"
+
+[tool.poetry.dev-dependencies]
+pytest = "^6.2"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+py-omop2neo4j-lpg = "omop2neo4j_lpg.cli:main"

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/__init__.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the omop2neo4j_lpg directory a Python package.

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/cli.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/cli.py
@@ -1,0 +1,126 @@
+import click
+from .config import settings, logger
+from . import extraction, loading, transformation, validation
+
+@click.group(context_settings=dict(help_option_names=['-h', '--help']))
+def main():
+    """
+    A CLI tool to orchestrate the migration of OMOP vocabulary tables
+    from PostgreSQL to a Neo4j Labeled Property Graph.
+
+    Configuration can be managed via a .env file in the current directory.
+    """
+    logger.info("py-omop2neo4j-lpg CLI started.")
+    pass
+
+@main.command()
+@click.option('--schema', default=settings.pg_schema, show_default=True, help='PostgreSQL schema containing OMOP tables.')
+@click.option('--export-dir', default=settings.export_dir, show_default=True, type=click.Path(), help='Local directory to export CSV files to.')
+def extract(schema, export_dir):
+    """Extracts OMOP tables from PostgreSQL to local CSV files."""
+    logger.info(f"Starting extraction from schema '{schema}' to '{export_dir}'...")
+    try:
+        extraction.extract_data(schema=schema, export_dir=export_dir)
+        logger.info("Extraction completed successfully.")
+    except Exception as e:
+        logger.error(f"Extraction failed: {e}", exc_info=True)
+        raise
+
+@main.command()
+@click.confirmation_option(prompt='This will WIPE the entire Neo4j database. Are you sure you want to continue?')
+def clear_db():
+    """Wipes the Neo4j database, deleting all nodes, relationships, and schema."""
+    logger.info("Starting database clearing process...")
+    driver = None
+    try:
+        driver = loading.get_neo4j_driver()
+        loading.clear_database(driver)
+        logger.info("Successfully cleared the database.")
+    except Exception as e:
+        logger.error(f"Failed to clear the database: {e}", exc_info=True)
+        raise
+    finally:
+        if driver:
+            driver.close()
+
+@main.command()
+@click.option('--batch-size', default=settings.load_csv_batch_size, show_default=True, help='Batch size for LOAD CSV transactions.')
+@click.option('--no-clean', is_flag=True, default=False, help="Do not clean the database before loading.")
+def load_csv(batch_size, no_clean):
+    """
+    Loads data into Neo4j using the online LOAD CSV method.
+    """
+    click.secho("--- IMPORTANT ---", fg="yellow")
+    click.echo(f"This command assumes the CSV files from the 'extract' command are present in your Neo4j server's configured import directory.")
+    click.secho("-----------------", fg="yellow")
+
+    logger.info("Starting online load process using LOAD CSV...")
+    driver = None
+    try:
+        driver = loading.get_neo4j_driver()
+
+        if not no_clean:
+            if click.confirm("This will WIPE the entire Neo4j database before loading. Continue?"):
+                loading.clear_database(driver)
+            else:
+                logger.warning("Load operation cancelled by user.")
+                return
+
+        loading.create_constraints_and_indexes(driver)
+        loading.load_metadata(driver)
+        loading.load_concepts(driver, batch_size=batch_size)
+        loading.load_relationships(driver, batch_size=batch_size)
+        loading.load_ancestors(driver, batch_size=batch_size)
+
+        logger.info("Online load completed successfully.")
+        click.secho("Running validation checks post-load...", fg="green")
+        validation.validate_graph()
+
+    except Exception as e:
+        logger.error(f"Online load failed: {e}", exc_info=True)
+        raise
+    finally:
+        if driver:
+            driver.close()
+
+@main.command()
+@click.option('--import-dir', default=settings.export_dir, show_default=True, type=click.Path(exists=True), help='Directory containing the source CSVs.')
+@click.option('--output-dir', default=settings.bulk_import_dir, show_default=True, type=click.Path(), help='Directory to save bulk-import-ready files.')
+@click.option('--chunk-size', default=settings.transformation_chunk_size, show_default=True, help='Chunk size for processing large CSVs.')
+def prepare_bulk(import_dir, output_dir, chunk_size):
+    """Transforms extracted CSVs into files for neo4j-admin bulk import."""
+    logger.info("Starting preparation for bulk import...")
+    try:
+        transformation.prepare_for_bulk_import(
+            import_dir=import_dir, output_dir=output_dir, chunk_size=chunk_size
+        )
+    except Exception as e:
+        logger.error(f"Bulk import preparation failed: {e}", exc_info=True)
+        raise
+
+@main.command()
+def create_indexes():
+    """Creates constraints and indexes. Essential after a bulk import."""
+    logger.info("Creating constraints and indexes in Neo4j...")
+    driver = None
+    try:
+        driver = loading.get_neo4j_driver()
+        loading.create_constraints_and_indexes(driver)
+    except Exception as e:
+        logger.error(f"Failed to create constraints/indexes: {e}", exc_info=True)
+        raise
+    finally:
+        if driver:
+            driver.close()
+
+@main.command()
+def validate():
+    """Runs validation checks against the loaded Neo4j graph."""
+    try:
+        validation.validate_graph()
+    except Exception as e:
+        logger.error(f"Validation failed: {e}", exc_info=True)
+        raise
+
+if __name__ == '__main__':
+    main()

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/config.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/config.py
@@ -1,0 +1,53 @@
+import logging
+import os
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+class Settings(BaseSettings):
+    """
+    Manages configuration for the application using Pydantic.
+    Loads settings from environment variables or a .env file.
+    """
+    # PostgreSQL Connection Settings
+    pg_host: str = "localhost"
+    pg_port: int = 5432
+    pg_user: str = "postgres"
+    pg_password: str = "password"
+    pg_database: str = "ohdsi"
+    pg_schema: str = "cdm_v5"
+
+    # Neo4j Connection Settings
+    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = "password"
+    neo4j_database: str = "neo4j"
+
+    # File Paths
+    export_dir: str = "export"
+    # The directory for neo4j-admin import files. Must be a path inside the Neo4j container's import directory.
+    bulk_import_dir: str = "import"
+
+    # Tuning Parameters
+    load_csv_batch_size: int = 10000
+    transformation_chunk_size: int = 100000
+
+    # Load settings from a .env file
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding='utf-8', extra='ignore')
+
+
+# Instantiate settings once and export
+settings = Settings()
+
+# Ensure the local directory for CSV exports exists
+try:
+    os.makedirs(settings.export_dir, exist_ok=True)
+    logger.info(f"Export directory '{settings.export_dir}' is ready.")
+except OSError as e:
+    logger.error(f"Failed to create export directory '{settings.export_dir}': {e}")

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/extraction.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/extraction.py
@@ -1,0 +1,105 @@
+import os
+import psycopg2
+from .config import settings, logger
+
+# SQL templates for extraction using COPY command.
+# We use `COPY ... TO STDOUT` and pipe the output to a local file using psycopg2's
+# `copy_expert`. This avoids file permission issues on the PostgreSQL server, which
+# is a common problem with `COPY ... TO 'filename'`.
+SQL_QUERIES = {
+    "concepts_optimized.csv": """
+        COPY (
+            SELECT
+                c.concept_id, c.concept_name, c.domain_id, c.vocabulary_id,
+                c.concept_class_id, c.standard_concept, c.concept_code,
+                to_char(c.valid_start_date, 'YYYY-MM-DD') as valid_start_date,
+                to_char(c.valid_end_date, 'YYYY-MM-DD') as valid_end_date,
+                c.invalid_reason,
+                string_agg(cs.concept_synonym_name, '|') AS synonyms
+            FROM
+                {schema}.concept c
+            LEFT JOIN
+                {schema}.concept_synonym cs ON c.concept_id = cs.concept_id
+            GROUP BY
+                c.concept_id
+        ) TO STDOUT WITH CSV HEADER FORCE QUOTE *
+    """,
+    "domain.csv": """
+        COPY {schema}.domain TO STDOUT WITH CSV HEADER FORCE QUOTE *
+    """,
+    "vocabulary.csv": """
+        COPY {schema}.vocabulary TO STDOUT WITH CSV HEADER FORCE QUOTE *
+    """,
+    "concept_relationship.csv": """
+        COPY (
+            SELECT concept_id_1, concept_id_2, relationship_id,
+                to_char(valid_start_date, 'YYYY-MM-DD') as valid_start_date,
+                to_char(valid_end_date, 'YYYY-MM-DD') as valid_end_date,
+                invalid_reason
+            FROM {schema}.concept_relationship
+        ) TO STDOUT WITH CSV HEADER FORCE QUOTE *
+    """,
+    "concept_ancestor.csv": """
+        COPY (
+            SELECT descendant_concept_id, ancestor_concept_id, min_levels_of_separation, max_levels_of_separation
+            FROM {schema}.concept_ancestor
+        ) TO STDOUT WITH CSV HEADER FORCE QUOTE *
+    """
+}
+
+
+def get_pg_connection():
+    """Establishes and returns a connection to the PostgreSQL database."""
+    try:
+        conn = psycopg2.connect(
+            dbname=settings.pg_database,
+            user=settings.pg_user,
+            password=settings.pg_password,
+            host=settings.pg_host,
+            port=settings.pg_port,
+        )
+        logger.info("Successfully connected to PostgreSQL.")
+        return conn
+    except psycopg2.OperationalError as e:
+        logger.error(f"Could not connect to PostgreSQL: {e}")
+        raise
+
+
+def extract_data(schema: str = settings.pg_schema, export_dir: str = settings.export_dir):
+    """
+    Extracts OMOP vocabulary tables from PostgreSQL to local CSV files.
+
+    Args:
+        schema (str): The database schema where OMOP tables reside.
+        export_dir (str): The local directory to save the CSV files into.
+    """
+    logger.info(f"Starting data extraction from schema '{schema}' to directory '{export_dir}'.")
+    conn = get_pg_connection()
+    if not conn:
+        return
+
+    try:
+        with conn.cursor() as cursor:
+            for filename, sql_template in SQL_QUERIES.items():
+                output_path = os.path.join(export_dir, filename)
+                logger.info(f"Exporting data to '{output_path}'...")
+
+                # Format the SQL with the correct schema
+                sql = sql_template.format(schema=schema)
+
+                try:
+                    with open(output_path, "w", encoding="utf-8") as f:
+                        # Use copy_expert to efficiently stream data to the local file
+                        cursor.copy_expert(sql, f)
+                    logger.info(f"Successfully exported '{filename}'.")
+                except (psycopg2.Error, IOError) as e:
+                    logger.error(f"Error exporting '{filename}': {e}")
+                    # Clean up the partially written file on error
+                    if os.path.exists(output_path):
+                        os.remove(output_path)
+                    raise
+        logger.info("All tables have been extracted successfully.")
+    finally:
+        if conn:
+            conn.close()
+            logger.info("PostgreSQL connection closed.")

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/loading.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/loading.py
@@ -1,0 +1,198 @@
+import os
+from neo4j import GraphDatabase, Driver
+from .config import settings, logger
+
+# --- Cypher Query Templates ---
+
+CLEAR_DB_QUERY = "MATCH (n) DETACH DELETE n"
+
+CONSTRAINTS_AND_INDEXES = [
+    "CREATE CONSTRAINT constraint_concept_id IF NOT EXISTS FOR (c:Concept) REQUIRE c.concept_id IS UNIQUE;",
+    "CREATE CONSTRAINT constraint_domain_id IF NOT EXISTS FOR (d:Domain) REQUIRE d.domain_id IS UNIQUE;",
+    "CREATE CONSTRAINT constraint_vocabulary_id IF NOT EXISTS FOR (v:Vocabulary) REQUIRE v.vocabulary_id IS UNIQUE;",
+    "CREATE INDEX index_concept_code IF NOT EXISTS FOR (c:Concept) ON (c.concept_code);",
+    "CREATE INDEX index_standard_label IF NOT EXISTS FOR (c:Standard) ON (c.concept_id);",
+]
+
+LOAD_DOMAINS_QUERY = """
+LOAD CSV WITH HEADERS FROM $uri AS row
+CREATE (d:Domain {
+    domain_id: row.domain_id,
+    domain_name: row.domain_name,
+    domain_concept_id: toInteger(row.domain_concept_id)
+});
+"""
+
+LOAD_VOCABULARIES_QUERY = """
+LOAD CSV WITH HEADERS FROM $uri AS row
+CREATE (v:Vocabulary {
+    vocabulary_id: row.vocabulary_id,
+    vocabulary_name: row.vocabulary_name,
+    vocabulary_reference: row.vocabulary_reference,
+    vocabulary_version: row.vocabulary_version,
+    vocabulary_concept_id: toInteger(row.vocabulary_concept_id)
+});
+"""
+
+LOAD_CONCEPTS_QUERY = """
+CALL {
+    LOAD CSV WITH HEADERS FROM $uri AS row
+    // 1. Create the Concept Node
+    CREATE (c:Concept {
+        concept_id: toInteger(row.concept_id),
+        name: row.concept_name,
+        domain_id: row.domain_id,
+        vocabulary_id: row.vocabulary_id,
+        concept_class_id: row.concept_class_id,
+        standard_concept: row.standard_concept,
+        concept_code: row.concept_code,
+        valid_start_date: date(row.valid_start_date),
+        valid_end_date: date(row.valid_end_date),
+        invalid_reason: row.invalid_reason,
+        synonyms: CASE WHEN row.synonyms IS NOT NULL AND row.synonyms <> '' THEN split(row.synonyms, '|') ELSE [] END
+    })
+
+    // 2. Add dynamic/conditional labels
+    WITH c, row
+    CALL apoc.text.capitalizeAll(apoc.text.replace(row.domain_id, '[^A-Za-z0-9_]', '_')) YIELD value as standardizedLabel
+    CALL apoc.create.addLabels(c, [standardizedLabel]) YIELD node
+
+    WITH c, row
+    // Add :Standard label conditionally. The inner query must return a value.
+    CALL apoc.do.when(
+        row.standard_concept = 'S',
+        'SET c:Standard RETURN 1',
+        '',
+        {c:c}
+    ) YIELD value
+
+    // 3. Create Contextual Edges
+    WITH c, row
+    MATCH (d:Domain {domain_id: row.domain_id})
+    CREATE (c)-[:IN_DOMAIN]->(d)
+    WITH c, row
+    MATCH (v:Vocabulary {vocabulary_id: row.vocabulary_id})
+    CREATE (c)-[:FROM_VOCABULARY]->(v)
+} IN TRANSACTIONS OF $batch_size ROWS
+"""
+
+LOAD_RELATIONSHIPS_QUERY = """
+CALL {
+    LOAD CSV WITH HEADERS FROM $uri AS row
+    MATCH (c1:Concept {concept_id: toInteger(row.concept_id_1)})
+    MATCH (c2:Concept {concept_id: toInteger(row.concept_id_2)})
+    WITH c1, c2, row, toupper(apoc.text.replace(row.relationship_id, '[^A-Za-z0-9_]', '_')) AS relType
+    CALL apoc.create.relationship(c1, relType, {
+        valid_start_date: date(row.valid_start_date),
+        valid_end_date: date(row.valid_end_date),
+        invalid_reason: row.invalid_reason
+    }, c2) YIELD rel
+    RETURN count(rel)
+} IN TRANSACTIONS OF $batch_size ROWS
+"""
+
+LOAD_ANCESTORS_QUERY = """
+CALL {
+    LOAD CSV WITH HEADERS FROM $uri AS row
+    MATCH (d:Concept {concept_id: toInteger(row.descendant_concept_id)})
+    MATCH (a:Concept {concept_id: toInteger(row.ancestor_concept_id)})
+    CREATE (d)-[r:HAS_ANCESTOR]->(a)
+    SET r.min_levels = toInteger(row.min_levels_of_separation),
+        r.max_levels = toInteger(row.max_levels_of_separation)
+} IN TRANSACTIONS OF $batch_size ROWS
+"""
+
+# --- Python Functions ---
+
+def get_neo4j_driver() -> Driver:
+    """Establishes and returns a connection to the Neo4j database."""
+    try:
+        driver = GraphDatabase.driver(
+            settings.neo4j_uri,
+            auth=(settings.neo4j_user, settings.neo4j_password),
+        )
+        driver.verify_connectivity()
+        logger.info("Successfully connected to Neo4j.")
+        return driver
+    except Exception as e:
+        logger.error(f"Could not connect to Neo4j: {e}")
+        raise
+
+
+def run_cypher_query(driver: Driver, query: str, database: str = settings.neo4j_database, **params):
+    """Helper function to run a Cypher query."""
+    try:
+        driver.execute_query(query, params, database=database)
+        logger.info(f"Successfully executed query: {query.strip().splitlines()[0][:80]}...")
+    except Exception as e:
+        logger.error(f"Error executing query: {query.strip().splitlines()[0][:80]}... : {e}")
+        raise
+
+
+def clear_database(driver: Driver):
+    """Clears the entire Neo4j database by dropping constraints, indexes, and deleting all nodes."""
+    logger.info("Clearing the database...")
+
+    # Drop all constraints
+    constraints_result = driver.execute_query("SHOW CONSTRAINTS", database=settings.neo4j_database)
+    for record in constraints_result.records:
+        constraint_name = record["name"]
+        logger.info(f"Dropping constraint: {constraint_name}")
+        run_cypher_query(driver, f"DROP CONSTRAINT {constraint_name}")
+
+    # Drop all indexes (that are not backing constraints)
+    indexes_result = driver.execute_query("SHOW INDEXES", database=settings.neo4j_database)
+    for record in indexes_result.records:
+        # Only drop indexes that are not backing constraints
+        if record["type"] != 'CONSTRAINT_BACKED':
+            index_name = record["name"]
+            logger.info(f"Dropping index: {index_name}")
+            run_cypher_query(driver, f"DROP INDEX {index_name}")
+
+    run_cypher_query(driver, CLEAR_DB_QUERY)
+    logger.info("Database cleared.")
+
+
+def create_constraints_and_indexes(driver: Driver):
+    """Creates all necessary constraints and indexes for the OMOP graph."""
+    logger.info("Creating constraints and indexes...")
+    for query in CONSTRAINTS_AND_INDEXES:
+        run_cypher_query(driver, query)
+    logger.info("Constraints and indexes created successfully.")
+
+
+def get_file_uri(filename: str) -> str:
+    """Constructs the file URI for Neo4j's LOAD CSV, which reads from its 'import' directory."""
+    return f"file:///{filename}"
+
+
+def load_metadata(driver: Driver):
+    """Loads Domain and Vocabulary CSV files into Neo4j."""
+    logger.info("Loading metadata: Domain and Vocabulary...")
+    run_cypher_query(driver, LOAD_DOMAINS_QUERY, uri=get_file_uri("domain.csv"))
+    run_cypher_query(driver, LOAD_VOCABULARIES_QUERY, uri=get_file_uri("vocabulary.csv"))
+    logger.info("Metadata loading complete.")
+
+
+def load_concepts(driver: Driver, batch_size: int):
+    """Loads the concepts_optimized.csv file into Neo4j."""
+    logger.info(f"Loading concepts with batch size {batch_size}...")
+    uri = get_file_uri("concepts_optimized.csv")
+    run_cypher_query(driver, LOAD_CONCEPTS_QUERY, uri=uri, batch_size=batch_size)
+    logger.info("Concept loading complete.")
+
+
+def load_relationships(driver: Driver, batch_size: int):
+    """Loads the concept_relationship.csv file into Neo4j."""
+    logger.info(f"Loading relationships with batch size {batch_size}...")
+    uri = get_file_uri("concept_relationship.csv")
+    run_cypher_query(driver, LOAD_RELATIONSHIPS_QUERY, uri=uri, batch_size=batch_size)
+    logger.info("Relationship loading complete.")
+
+
+def load_ancestors(driver: Driver, batch_size: int):
+    """Loads the concept_ancestor.csv file into Neo4j."""
+    logger.info(f"Loading ancestors with batch size {batch_size}...")
+    uri = get_file_uri("concept_ancestor.csv")
+    run_cypher_query(driver, LOAD_ANCESTORS_QUERY, uri=uri, batch_size=batch_size)
+    logger.info("Ancestor loading complete.")

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/transformation.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/transformation.py
@@ -1,0 +1,170 @@
+import pandas as pd
+import os
+from .config import settings, logger
+from .utils import standardize_label, standardize_reltype
+
+def _write_chunk(df, filepath, is_first_chunk):
+    """Helper to write DataFrame chunk to a CSV file."""
+    df.to_csv(filepath, mode='a', header=is_first_chunk, index=False)
+
+def transform_metadata_nodes(import_dir, output_dir):
+    """Transforms domain and vocabulary CSVs into node files for bulk import."""
+    logger.info("Transforming metadata nodes (Domain, Vocabulary)...")
+
+    # Domain nodes
+    domain_file = os.path.join(import_dir, 'domain.csv')
+    df_domain = pd.read_csv(domain_file, dtype=str)
+    df_domain[':LABEL'] = 'Domain'
+    df_domain.rename(columns={'domain_id': ':ID(Domain-ID)'}, inplace=True)
+    domain_nodes = df_domain[[':ID(Domain-ID)', ':LABEL', 'domain_name', 'domain_concept_id']]
+    domain_nodes.to_csv(os.path.join(output_dir, 'nodes_domain.csv'), index=False)
+
+    # Vocabulary nodes
+    vocab_file = os.path.join(import_dir, 'vocabulary.csv')
+    df_vocab = pd.read_csv(vocab_file, dtype=str)
+    df_vocab[':LABEL'] = 'Vocabulary'
+    df_vocab.rename(columns={'vocabulary_id': ':ID(Vocabulary-ID)'}, inplace=True)
+    vocab_nodes = df_vocab[[':ID(Vocabulary-ID)', ':LABEL', 'vocabulary_name', 'vocabulary_reference', 'vocabulary_version', 'vocabulary_concept_id']]
+    vocab_nodes.to_csv(os.path.join(output_dir, 'nodes_vocabulary.csv'), index=False)
+    logger.info("Metadata node transformation complete.")
+
+def transform_concepts_and_contextual_rels(import_dir, output_dir, chunk_size):
+    """Transforms concept CSV into node and contextual relationship files, using chunking."""
+    logger.info("Transforming concept nodes and contextual relationships...")
+    source_file = os.path.join(import_dir, 'concepts_optimized.csv')
+    node_file = os.path.join(output_dir, 'nodes_concepts.csv')
+    rel_domain_file = os.path.join(output_dir, 'rels_in_domain.csv')
+    rel_vocab_file = os.path.join(output_dir, 'rels_from_vocabulary.csv')
+
+    # Ensure files are empty before starting
+    for f in [node_file, rel_domain_file, rel_vocab_file]:
+        if os.path.exists(f): os.remove(f)
+
+    iter_csv = pd.read_csv(source_file, chunksize=chunk_size, dtype=str, keep_default_na=False)
+
+    for i, chunk in enumerate(iter_csv):
+        is_first = (i == 0)
+        # --- Process Nodes ---
+        chunk.rename(columns={
+            'concept_id': ':ID(Concept-ID)',
+            'concept_name': 'name:string',
+            'synonyms': 'synonyms:string[]',
+            'valid_start_date': 'valid_start_date:date',
+            'valid_end_date': 'valid_end_date:date'
+        }, inplace=True)
+
+        chunk['domain_label'] = chunk['domain_id'].apply(standardize_label)
+        chunk[':LABEL'] = 'Concept;' + chunk['domain_label']
+        chunk.loc[chunk['standard_concept'] == 'S', ':LABEL'] += ';Standard'
+
+        node_cols = [':ID(Concept-ID)', ':LABEL', 'name:string', 'domain_id', 'vocabulary_id',
+                     'concept_class_id', 'standard_concept', 'concept_code',
+                     'valid_start_date:date', 'valid_end_date:date', 'invalid_reason', 'synonyms:string[]']
+        _write_chunk(chunk[node_cols], node_file, is_first)
+
+        # --- Process Contextual Relationships ---
+        rels_domain_chunk = pd.DataFrame({
+            ':START_ID(Concept-ID)': chunk[':ID(Concept-ID)'],
+            ':END_ID(Domain-ID)': chunk['domain_id'],
+            ':TYPE': 'IN_DOMAIN'
+        })
+        _write_chunk(rels_domain_chunk, rel_domain_file, is_first)
+
+        rels_vocab_chunk = pd.DataFrame({
+            ':START_ID(Concept-ID)': chunk[':ID(Concept-ID)'],
+            ':END_ID(Vocabulary-ID)': chunk['vocabulary_id'],
+            ':TYPE': 'FROM_VOCABULARY'
+        })
+        _write_chunk(rels_vocab_chunk, rel_vocab_file, is_first)
+        logger.info(f"Processed concept chunk {i+1}...")
+
+def transform_semantic_rels(import_dir, output_dir, chunk_size):
+    """Transforms relationship CSV into semantic relationship files, using chunking."""
+    logger.info("Transforming semantic relationships...")
+    source_file = os.path.join(import_dir, 'concept_relationship.csv')
+    output_file = os.path.join(output_dir, 'rels_semantic.csv')
+    if os.path.exists(output_file): os.remove(output_file)
+
+    iter_csv = pd.read_csv(source_file, chunksize=chunk_size, dtype=str, keep_default_na=False)
+
+    for i, chunk in enumerate(iter_csv):
+        chunk.rename(columns={
+            'concept_id_1': ':START_ID(Concept-ID)',
+            'concept_id_2': ':END_ID(Concept-ID)',
+            'valid_start_date': 'valid_start_date:date',
+            'valid_end_date': 'valid_end_date:date'
+        }, inplace=True)
+        chunk[':TYPE'] = chunk['relationship_id'].apply(standardize_reltype)
+
+        rel_cols = [':START_ID(Concept-ID)', ':END_ID(Concept-ID)', ':TYPE',
+                    'valid_start_date:date', 'valid_end_date:date', 'invalid_reason']
+        _write_chunk(chunk[rel_cols], output_file, (i == 0))
+        logger.info(f"Processed semantic relationship chunk {i+1}...")
+
+def transform_ancestor_rels(import_dir, output_dir, chunk_size):
+    """Transforms ancestor CSV into ancestor relationship files, using chunking."""
+    logger.info("Transforming ancestor relationships...")
+    source_file = os.path.join(import_dir, 'concept_ancestor.csv')
+    output_file = os.path.join(output_dir, 'rels_ancestor.csv')
+    if os.path.exists(output_file): os.remove(output_file)
+
+    iter_csv = pd.read_csv(source_file, chunksize=chunk_size, dtype=str, keep_default_na=False)
+
+    for i, chunk in enumerate(iter_csv):
+        chunk.rename(columns={
+            'descendant_concept_id': ':START_ID(Concept-ID)',
+            'ancestor_concept_id': ':END_ID(Concept-ID)',
+            'min_levels_of_separation': 'min_levels:int',
+            'max_levels_of_separation': 'max_levels:int'
+        }, inplace=True)
+        chunk[':TYPE'] = 'HAS_ANCESTOR'
+
+        rel_cols = [':START_ID(Concept-ID)', ':END_ID(Concept-ID)', ':TYPE', 'min_levels:int', 'max_levels:int']
+        _write_chunk(chunk[rel_cols], output_file, (i == 0))
+        logger.info(f"Processed ancestor relationship chunk {i+1}...")
+
+def generate_import_command(output_dir, db_name):
+    """Generates and prints the neo4j-admin import command."""
+    command = f"""
+# --- neo4j-admin database import full command ---
+# 1. Stop your Neo4j server.
+# 2. Ensure the files listed below are in your Neo4j 'import' directory.
+#    The path '{output_dir}' should be relative to the Neo4j import directory.
+# 3. Run the command below from your shell. Adjust memory settings if needed.
+# 4. After a successful import, start your Neo4j server.
+# 5. Run 'py-omop2neo4j-lpg create-indexes' to build schema indexes.
+
+neo4j-admin database import full \\
+  --nodes="{os.path.join(output_dir, 'nodes_domain.csv')}" \\
+  --nodes="{os.path.join(output_dir, 'nodes_vocabulary.csv')}" \\
+  --nodes="{os.path.join(output_dir, 'nodes_concepts.csv')}" \\
+  --relationships="{os.path.join(output_dir, 'rels_in_domain.csv')}" \\
+  --relationships="{os.path.join(output_dir, 'rels_from_vocabulary.csv')}" \\
+  --relationships="{os.path.join(output_dir, 'rels_semantic.csv')}" \\
+  --relationships="{os.path.join(output_dir, 'rels_ancestor.csv')}" \\
+  --delimiter=',' --array-delimiter='|' --multiline-fields=true \\
+  {db_name}
+"""
+    logger.info("--- Generated neo4j-admin import command ---")
+    print(command)
+
+def prepare_for_bulk_import(
+    import_dir: str = settings.export_dir,
+    output_dir: str = settings.bulk_import_dir,
+    chunk_size: int = settings.transformation_chunk_size
+):
+    """
+    Orchestrates the transformation of extracted CSVs into files
+    formatted for Neo4j's bulk import tool.
+    """
+    logger.info(f"Starting transformation for bulk import. Chunk size: {chunk_size}")
+    os.makedirs(output_dir, exist_ok=True)
+
+    transform_metadata_nodes(import_dir, output_dir)
+    transform_concepts_and_contextual_rels(import_dir, output_dir, chunk_size)
+    transform_semantic_rels(import_dir, output_dir, chunk_size)
+    transform_ancestor_rels(import_dir, output_dir, chunk_size)
+
+    generate_import_command(output_dir, settings.neo4j_database)
+
+    logger.info(f"Transformation complete. Files for bulk import are ready in '{output_dir}'.")

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/utils.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/utils.py
@@ -1,0 +1,38 @@
+import re
+from typing import Optional
+
+def standardize_label(s: Optional[str]) -> str:
+    """
+    Sanitizes and converts a string to UpperCamelCase for use as a Neo4j label.
+    - Replaces non-alphanumeric characters (except '_') with '_'.
+    - Converts the string to UpperCamelCase from snake_case.
+
+    Examples:
+    - "spec_anatomic_site" -> "SpecAnatomicSite"
+    - "Condition/Era" -> "Condition_Era" -> "ConditionEra"
+    - "Drug" -> "Drug"
+    """
+    if not isinstance(s, str) or not s:
+        return ""
+    # Replace any character that is not a letter, number, or underscore with an underscore
+    sanitized = re.sub(r'[^a-zA-Z0-9_]', '_', s)
+    # Split by underscore, capitalize each part, and join
+    # The `if word` handles cases of multiple underscores leading to empty strings
+    return "".join(word.capitalize() for word in sanitized.split('_') if word)
+
+def standardize_reltype(s: Optional[str]) -> str:
+    """
+    Sanitizes and converts a string to UPPER_SNAKE_CASE for use as a Neo4j relationship type.
+    - Replaces non-alphanumeric characters (except '_') with an underscore.
+    - Converts the resulting string to uppercase.
+
+    Examples:
+    - "Maps to" -> "MAPS_TO"
+    - "Subsumes" -> "SUBSUMES"
+    - "Concept replaced by" -> "CONCEPT_REPLACED_BY"
+    """
+    if not isinstance(s, str) or not s:
+        return ""
+    # Replace any character that is not a letter, number, or underscore with an underscore
+    sanitized = re.sub(r'[^a-zA-Z0-9_]', '_', s)
+    return sanitized.upper()

--- a/py-omop2neo4j-lpg/src/omop2neo4j_lpg/validation.py
+++ b/py-omop2neo4j-lpg/src/omop2neo4j_lpg/validation.py
@@ -1,0 +1,120 @@
+from neo4j import Driver
+from .config import settings, logger
+from .loading import get_neo4j_driver
+
+def _run_read_query(driver: Driver, query: str, **params):
+    """Helper to run a read-only Cypher query and return the records."""
+    try:
+        # routing_='r' is not a standard parameter for execute_query
+        # The session will determine if it's a read or write transaction.
+        result, _, _ = driver.execute_query(query, params, database=settings.neo4j_database)
+        return result
+    except Exception as e:
+        logger.error(f"Error executing validation query: {query[:80]}... : {e}")
+        raise
+
+def _print_header(title: str):
+    """Prints a formatted header to the console."""
+    print("\n" + "="*60)
+    print(f" {title.upper()} ".center(60, "="))
+    print("="*60)
+
+def check_node_counts(driver: Driver):
+    """Checks and prints counts of nodes by label."""
+    _print_header("Node Count Validation")
+
+    total_nodes = _run_read_query(driver, "MATCH (n) RETURN count(n) AS count")[0]['count']
+    print(f"Total nodes in database: {total_nodes:,}")
+
+    print("\n--- Counts by Core Label ---")
+    for label in ["Concept", "Domain", "Vocabulary", "Standard"]:
+        count = _run_read_query(driver, f"MATCH (n:{label}) RETURN count(n) AS count")[0]['count']
+        print(f"- Nodes with label :{label}: {count:,}")
+
+    print("\n--- Sample Counts for Dynamic Domain Labels ---")
+    labels_in_use = [r['label'] for r in _run_read_query(driver, "CALL db.labels() YIELD label")]
+    sample_dynamic_labels = sorted([l for l in labels_in_use if l not in ["Concept", "Domain", "Vocabulary", "Standard"]])
+
+    if not sample_dynamic_labels:
+        print("No dynamic domain labels found.")
+    else:
+        for label in sample_dynamic_labels[:10]: # Print up to 10 dynamic labels
+            count = _run_read_query(driver, f"MATCH (n:`{label}`) RETURN count(n) AS count")[0]['count']
+            print(f"- Nodes with label :{label}: {count:,}")
+
+def check_relationship_counts(driver: Driver):
+    """Checks and prints counts of relationships by type."""
+    _print_header("Relationship Count Validation")
+
+    total_rels = _run_read_query(driver, "MATCH ()-[r]->() RETURN count(r) AS count")[0]['count']
+    print(f"Total relationships in database: {total_rels:,}")
+
+    print("\n--- Counts by Relationship Type ---")
+    # This query is more efficient than calling apoc.cypher.run in a loop
+    rel_types_counts = _run_read_query(driver, """
+        CALL db.relationshipTypes() YIELD relationshipType
+        MATCH ()-[r]->() WHERE type(r) = relationshipType
+        RETURN relationshipType, count(r) as count
+        ORDER BY count DESC
+    """)
+    for record in rel_types_counts:
+        print(f"- Relationships of type :{record['relationshipType']}: {record['count']:,}")
+
+def check_sample_concept(driver: Driver, concept_id: int = 1177480):
+    """Inspects a sample concept to verify its properties, labels, and relationships."""
+    _print_header(f"Sample Concept Validation (Concept ID: {concept_id})")
+
+    concept_data = _run_read_query(driver, "MATCH (c:Concept {concept_id: $id}) RETURN c, labels(c) as labels", id=concept_id)
+    if not concept_data:
+        print(f"ERROR: Concept with ID {concept_id} not found.")
+        return
+
+    record = concept_data[0]
+    properties = record['c']
+    labels = record['labels']
+
+    print(f"Found Concept: '{properties.get('name')}'")
+    print(f"Labels: {labels}")
+    print("\n--- Properties ---")
+    for key, value in sorted(properties.items()):
+        print(f"- {key}: {value}")
+
+    print("\n--- Sample Relationships (LIMIT 25) ---")
+    relationships = _run_read_query(driver, """
+        MATCH (c:Concept {concept_id: $id})-[r]-(n)
+        RETURN type(r) as rel_type, n.name as other_name, labels(n) as other_labels, n.concept_id as other_id
+        LIMIT 25
+    """, id=concept_id)
+
+    if not relationships:
+        print("No relationships found for this concept.")
+    else:
+        for rel in relationships:
+            print(f"- [:{rel['rel_type']}]->(name: '{rel['other_name']}', id: {rel['other_id']}, labels: {rel['other_labels']})")
+
+    ancestors = _run_read_query(driver, """
+        MATCH (c:Concept {concept_id: $id})-[:HAS_ANCESTOR]->(a)
+        RETURN a.concept_id as ancestor_id, a.name as ancestor_name
+        LIMIT 5
+    """, id=concept_id)
+    if ancestors:
+        print("\n--- Sample Ancestors (LIMIT 5) ---")
+        for ancestor in ancestors:
+            print(f"- {ancestor['ancestor_name']} (ID: {ancestor['ancestor_id']})")
+
+def validate_graph():
+    """Main entry point function to run all validation checks."""
+    logger.info("Starting graph validation...")
+    driver = None
+    try:
+        driver = get_neo4j_driver()
+        check_node_counts(driver)
+        check_relationship_counts(driver)
+        check_sample_concept(driver) # Use default Aspirin concept
+        logger.info("Graph validation complete.")
+    except Exception as e:
+        logger.error(f"An error occurred during validation: {e}", exc_info=True)
+    finally:
+        if driver:
+            driver.close()
+            logger.info("Neo4j connection for validation closed.")


### PR DESCRIPTION
This commit introduces the full implementation of the `py-omop2neo4j-lpg` package, a command-line tool for migrating OMOP vocabulary data from PostgreSQL to a Neo4j Labeled Property Graph.

The package adheres to the detailed project specification, providing two distinct loading methods:
1.  An online `LOAD CSV` method for smaller datasets, using batched Cypher queries and APOC procedures.
2.  An offline `neo4j-admin import` method for large-scale migrations, featuring a memory-efficient transformation step that processes data in chunks.

Key features include:
- A rich, standardized graph model with dynamic labels and relationship types.
- A robust CLI built with `click` to orchestrate the entire ETL process.
- Comprehensive data validation, configuration management via `pydantic-settings`, and detailed logging.
- Full documentation, including a `README.md`, `.env.example`, and `docker-compose.yml` for easy setup and use.