### PR TITLE
fix(ci): Accept Neo4j license agreement in workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,6 +29,7 @@ jobs:
         image: neo4j:latest
         env:
           NEO4J_AUTH: neo4j/StrongPass123
+          NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
           NEO4J_apoc_import_file_enabled: "true"
           NEO4J_apoc_import_file_use__neo4j__config: "true"
           NEO4JLABS_PLUGINS: '["apoc"]'


### PR DESCRIPTION
The GitHub Actions workflow was failing because the Neo4j service container could not start. This was due to a missing license agreement acceptance, which is required for recent versions of the Neo4j Docker image.

This commit adds the `NEO4J_ACCEPT_LICENSE_AGREEMENT` environment variable to the `neo4j` service definition in the workflow file to resolve the issue.