### PR TITLE
fix(ci): Resolve Neo4j container initialization failure

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -26,10 +26,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       neo4j:
-        image: neo4j:latest
+        image: neo4j:4.4.11-community
         env:
           NEO4J_AUTH: neo4j/StrongPass123
-          NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
           NEO4J_apoc_import_file_enabled: "true"
           NEO4J_apoc_import_file_use__neo4j__config: "true"
           NEO4JLABS_PLUGINS: '["apoc"]'
@@ -37,7 +36,7 @@ jobs:
           - "7475:7474"
           - "7688:7687"
         options: >-
-          --health-cmd "wget -O /dev/null --server-response --timeout=2 http://localhost:7474 2>&1 | awk '/^  HTTP/{print $$2}' | grep -q 200"
+          --health-cmd "wget -O /dev/null --server-response --timeout=2 http://localhost:7475 2>&1 | awk '/^  HTTP/{print $2}' | grep -q 200"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
The GitHub Actions workflow was failing because the `neo4j:latest` service container could not be initialized. This was due to two issues:

1. The `neo4j:latest` tag points to an enterprise version of Neo4j, which requires accepting a license agreement. The workflow was attempting to set this, but the container still failed to start.

2. The health check for the Neo4j service was using an incorrect port (`7474` instead of `7475`) and had a syntax error in the `awk` command.

This commit resolves these issues by:

- Pinning the Neo4j image to a specific community version (`4.4.11-community`) to avoid license issues.
- Removing the now-unnecessary `NEO4J_ACCEPT_LICENSE_AGREEMENT` environment variable.
- Correcting the health check command to use the correct host port (`7475`) and fixing the `awk` syntax.