### PR TITLE
fix(ci): Resolve Neo4j container initialization failure (#48)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,6 +29,7 @@ jobs:
         image: neo4j:4.4.11-community
         env:
           NEO4J_AUTH: neo4j/StrongPass123
+          NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
           NEO4J_apoc_import_file_enabled: "true"
           NEO4J_apoc_import_file_use__neo4j__config: "true"
           NEO4JLABS_PLUGINS: '["apoc"]'


### PR DESCRIPTION
The GitHub Actions workflow was failing because the Neo4j service container could not be initialized. This was due to the missing `NEO4J_ACCEPT_LICENSE_AGREEMENT` environment variable, which is required to run the Neo4j container.

This commit adds the `NEO4J_ACCEPT_LICENSE_AGREEMENT=yes` environment variable to the `neo4j` service definition in the `python-test.yml` workflow file. This resolves the container initialization failure and allows the tests to run successfully.