### PR TITLE
fix(ci): Correct Neo4j healthcheck port in workflow (#50)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,7 +37,7 @@ jobs:
           - "7475:7474"
           - "7688:7687"
         options: >-
-          --health-cmd "wget -O /dev/null --server-response --timeout=2 http://localhost:7475 2>&1 | awk '/^  HTTP/{print $2}' | grep -q 200"
+          --health-cmd "wget -O /dev/null --server-response --timeout=2 http://localhost:7474 2>&1 | awk '/^  HTTP/{print $2}' | grep -q 200"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
The GitHub Actions workflow was failing because the healthcheck for the Neo4j service was using the wrong port. The healthcheck was trying to access port 7475, which is the host port, instead of port 7474, which is the container's internal port.

This change corrects the healthcheck command to use port 7474, which should resolve the container initialization failure