### PR TITLE
fix(ci): Resolve test failures in GitHub workflow

### DIFF
--- a/src/omop2neo4j_lpg/config.py
+++ b/src/omop2neo4j_lpg/config.py
@@ -52,8 +52,13 @@ settings = get_settings()
 
 # --- Logging ---
 # Create export directory if it doesn't exist to store logs
-os.makedirs(settings.EXPORT_DIR, exist_ok=True)
-log_file_path = os.path.join(settings.EXPORT_DIR, settings.LOG_FILE)
+if "pytest" in sys.modules:
+    log_dir = "/tmp"
+else:
+    log_dir = settings.EXPORT_DIR
+    os.makedirs(log_dir, exist_ok=True)
+
+log_file_path = os.path.join(log_dir, settings.LOG_FILE)
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,19 @@
 import os
 import shutil
 import pytest
+from omop2neo4j_lpg.config import settings
+
+@pytest.fixture(scope="session")
+def test_export_dir():
+    """Creates a directory for test exports."""
+    export_dir = "./export_test"
+    os.makedirs(export_dir, exist_ok=True)
+    yield export_dir
 
 @pytest.fixture(autouse=True)
-def clean_export_dir():
+def clean_export_dir(test_export_dir):
     """Cleans the export_test directory before each test."""
-    export_dir = "./export_test"
+    export_dir = test_export_dir
     if os.path.exists(export_dir):
         for item in os.listdir(export_dir):
             item_path = os.path.join(export_dir, item)
@@ -13,3 +21,8 @@ def clean_export_dir():
                 shutil.rmtree(item_path)
             else:
                 os.remove(item_path)
+
+@pytest.fixture(autouse=True)
+def monkeypatch_settings(monkeypatch, test_export_dir):
+    """Monkeypatches the settings for the test environment."""
+    monkeypatch.setattr(settings, "EXPORT_DIR", test_export_dir)


### PR DESCRIPTION
The GitHub workflow was failing due to a combination of permission errors and incorrect file paths during testing.

This commit resolves these issues by:

- Modifying the logging configuration to use a temporary directory during tests, which avoids permission errors when creating the log file.
- Updating the test configuration to use a dedicated directory for test exports (`./export_test`) and monkeypatching the application settings to use this directory. This ensures that the Neo4j container can access the exported CSV files for data loading.

With these changes, the tests now pass successfully in the CI environment.