### PR TITLE
Fix(CI): Increase sleep time in workflow to fix race condition (#56)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Initialize DB
         run: |
-          sleep 10
+          sleep 30
           PGPASSWORD=testpass psql -h localhost -p 5433 -U testuser -d testdb -f tests/sample_data/init.sql
 
       - name: Run tests


### PR DESCRIPTION
The GitHub Actions workflow was failing with a `connection refused` error when trying to initialize the database. This indicates that the postgres service was not yet ready to accept connections.

This commit increases the sleep time in the `Initialize DB` step from 10 to 30 seconds to give the service more time to become available. This should make the workflow more robust and prevent this race condition from happening in the future.