### PR TITLE
Fix(CI): Correct Neo4j service configuration in GitHub Actions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,9 +32,9 @@ jobs:
           NEO4J_apoc_import_file_use__neo4j__config: "true"
           NEO4JLABS_PLUGINS: '["apoc"]'
         ports:
-          - "7475:7474"
-          - "7688:7687"
-        options: --health-cmd "wget -O /dev/null --server-response --timeout=2 http://localhost:7474 2>&1 | awk '/^  HTTP/{print $2}' | grep -q 200" --health-interval 5s --health-timeout 5s --health-retries 10
+          - "7474:7474"
+          - "7687:7687"
+        options: --health-cmd "wget -O /dev/null --server-response --timeout=2 http://neo4j:7474 2>&1 | awk '/^  HTTP/{print $2}' | grep -q 200" --health-interval 5s --health-timeout 5s --health-retries 10
 
     steps:
       - name: Checkout code
@@ -62,6 +62,6 @@ jobs:
           POSTGRES_DB: testdb
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: testpass
-          NEO4J_URI: bolt://localhost:7688
+          NEO4J_URI: bolt://neo4j:7687
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: StrongPass123


### PR DESCRIPTION
The previous workflow configuration had two issues:

1. The Neo4j service was being accessed at `localhost` within the test job, but services in GitHub Actions are accessible via their service name.
2. The health check for the Neo4j service was also incorrectly targeting `localhost`.

This commit corrects the `NEO4J_URI` to use the service name `neo4j` and updates the health check to target `http://neo4j:7474`. The port mapping for the neo4j service was also updated to map to the default ports.