### PR TITLE
Fix: Trigger GitHub Actions on main and develop branches

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -3,9 +3,11 @@ name: Run Python Tests
 on:
   push:
     branches:
+      - main
       - develop
   pull_request:
     branches:
+      - main
       - develop
 
 jobs:


### PR DESCRIPTION
The GitHub Actions workflow was previously configured to only trigger on pushes and pull requests to the `develop` branch.

This change updates the workflow to also trigger on pushes and pull requests to the `main` branch, ensuring that tests are run for both branches.