### PR TITLE
Fix failing python test workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --no-root
+          poetry install --no-root --with test
           sudo apt-get update && sudo apt-get install -y postgresql-client
 
       - name: Wait for PostgreSQL to be healthy


### PR DESCRIPTION
The python test workflow was failing because it was not installing the test dependencies. This change adds the `--with test` flag to the `poetry install` command to ensure that the test dependencies, including pytest, are installed before the tests are run.